### PR TITLE
Fix typo in init.js

### DIFF
--- a/lib/commands/init/init.js
+++ b/lib/commands/init/init.js
@@ -58,7 +58,7 @@ const logDone = () =>
     emojify(
       `\n:rocket: ${chalk.green(
         "Done!"
-      )} You can not start your app with ${command(
+      )} You can now start your app with ${command(
         "boogi develop"
       )} or build it with ${command("boogi build")} :fire:`
     )


### PR DESCRIPTION
Mixing up _not_ and _now_ is a typo I often make myself! This should avoid confusion after running `boogi init` so that the user can move on to the next step with confidence.