### PR TITLE
Use `path` module instead of string concatenation

### DIFF
--- a/lib/commands/init/files.js
+++ b/lib/commands/init/files.js
@@ -69,7 +69,7 @@ const traverse = (baseDir, dir, copy, create) => {
     if (fs.lstatSync(fullPath).isDirectory()) {
       traverse(baseDir, fullPath, copy, create);
     } else {
-      const relPath = fullPath.replace(`${baseDir}/`, "");
+      const relPath = path.relative(baseDir, fullPath)
       const parts = relPath.split(".");
       const extension = parts[parts.length - 1].toLowerCase();
       if (
@@ -86,7 +86,7 @@ const traverse = (baseDir, dir, copy, create) => {
 };
 
 export const initFiles = (config, ctx, task) => {
-  const templatesRootDir = root() + "/assets/templates";
+  const templatesRootDir = path.resolve(root(), "assets/templates");
   const fullConfig = { package: packageData, context: ctx, config: config };
   const templater = new FileTemplater(fullConfig, templatesRootDir);
   const create = (name) => {

--- a/lib/utils/package.js
+++ b/lib/utils/package.js
@@ -1,8 +1,8 @@
+const path = require('path');
 
 export const packageData = require('../../package.json');
 
 export const root = () => {
-    const fullPath = require.main.filename;
-    const parts = fullPath.split("/");
-    return parts.splice(0, parts.length - 2).join("/");
-  };
+  const fullPath = require.main.filename;
+  return path.resolve(fullPath + '/../..');
+};


### PR DESCRIPTION
Paths manipulation now works on Windows too.

Fixes #21.